### PR TITLE
Fix simple key usage.

### DIFF
--- a/src/Flow/JSONPath/JSONPath.php
+++ b/src/Flow/JSONPath/JSONPath.php
@@ -88,7 +88,7 @@ class JSONPath implements ArrayAccess, Iterator, JsonSerializable
         }
 
         $value = $this->data[end($keys)] ? $this->data[end($keys)] : null;
-        
+
         return AccessHelper::isCollectionType($value) ? new static($value, $this->options) : $value;
     }
 
@@ -120,9 +120,6 @@ class JSONPath implements ArrayAccess, Iterator, JsonSerializable
         if (isset(static::$tokenCache[$cacheKey])) {
             return static::$tokenCache[$cacheKey];
         }
-
-        $expression = trim($expression);
-        $expression = preg_replace('/^\$/', '', $expression);
 
         $lexer = new JSONPathLexer($expression);
 

--- a/src/Flow/JSONPath/JSONPathLexer.php
+++ b/src/Flow/JSONPath/JSONPathLexer.php
@@ -33,9 +33,38 @@ class JSONPathLexer
     const MATCH_QUERY_MATCH  = '\s* \?\(.+?\) \s*';
     const MATCH_INDEX_ALT    = '\s* ["\']? (.+?) ["\']? \s*';
 
+    /**
+     * The expression being lexed.
+     *
+     * @var string
+     */
+    protected $expression = '';
+
+    /**
+     * The length of the expression.
+     *
+     * @var int
+     */
+    protected $expressionLength = 0;
+
     public function __construct($expression)
     {
+        $expression = trim($expression);
+
+        if (!strlen($expression)) {
+            return;
+        }
+
+        if ($expression[0] === '$') {
+            $expression = substr($expression, 1);
+        }
+
+        if ($expression[0] !== '.' && $expression[0] !== '[') {
+            $expression = '.' . $expression;
+        }
+
         $this->expression = $expression;
+        $this->expressionLength = strlen($expression);
     }
 
     public function parseExpressionGroups()
@@ -44,16 +73,12 @@ class JSONPathLexer
         $capturing = false;
         $group = '';
         $groups = [];
-        $token = array(
-            'value' => '',
-            'type' => '',
-        );
 
-        for ($i = 0; $i < strlen($this->expression); $i += 1) {
+        for ($i = 0; $i < $this->expressionLength; $i++) {
             $char = $this->expression[$i];
 
             if ($char === '.' && $squareBracketDepth === 0) {
-                if (! empty($group) && $group !== '.') {
+                if ($group !== '' && $group !== '.') {
                     $groups[] = $group;
                     $group = '';
                 }
@@ -62,7 +87,7 @@ class JSONPathLexer
 
             if ($char == "[") {
                 if ($squareBracketDepth === 0) {
-                    if (! empty($group)) {
+                    if ($group !== '') {
                         $groups[] = $group;
                         $group = '';
                     }
@@ -89,7 +114,7 @@ class JSONPathLexer
 
         }
 
-        if (! empty($group)) {
+        if ($group !== '') {
             $groups[] = $group;
         }
 

--- a/tests/JSONPathTest.php
+++ b/tests/JSONPathTest.php
@@ -212,6 +212,16 @@ class JSONPathTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(19.95, $result[26]);
     }
 
+    /**
+     * Tests direct key access.
+     */
+    public function testSimpleArrayAccess()
+    {
+        $result = (new JSONPath(array('title' => 'test title')))->find('title');
+
+        $this->assertEquals(array('test title'), $result->data());
+    }
+
     public function testFilteringOnNoneArrays()
     {
         $data = ['foo' => 'asdf'];


### PR DESCRIPTION
Defining the $ or . as a prefix is optional. This works in the original implementation.

Also, fixed usage of empty() where $group could be the string "0", and some other minor cleanups like moving all expression sanitizing to the lexer.