### PR TITLE
Fix expression $ failing in PHP 7.2

### DIFF
--- a/src/Flow/JSONPath/JSONPathLexer.php
+++ b/src/Flow/JSONPath/JSONPathLexer.php
@@ -57,11 +57,14 @@ class JSONPathLexer
         $this->expressionLength = $len;
     }
 
+    /**
+     * @return array
+     * @throws JSONPathException
+     */
     public function parseExpressionTokens()
     {
         $dotIndexDepth = 0;
         $squareBracketDepth = 0;
-        $capturing = false;
         $tokenValue = '';
         $tokens = [];
 
@@ -130,7 +133,6 @@ class JSONPathLexer
 
         if ($tokenValue !== '') {
             $tokens[] = $this->createToken($tokenValue);
-            $tokenValue = '';
         }
 
         return $tokens;
@@ -158,6 +160,7 @@ class JSONPathLexer
     /**
      * @param $value
      * @return string
+     * @throws JSONPathException
      */
     protected function createToken($value)
     {
@@ -218,5 +221,4 @@ class JSONPathLexer
 
         throw new JSONPathException("Unable to parse token {$value} in expression: $this->expression");
     }
-
 }

--- a/src/Flow/JSONPath/JSONPathLexer.php
+++ b/src/Flow/JSONPath/JSONPathLexer.php
@@ -35,20 +35,26 @@ class JSONPathLexer
     {
         $expression = trim($expression);
 
-        if (!strlen($expression)) {
+        $len = strlen($expression);
+        if (!$len) {
             return;
         }
 
         if ($expression[0] === '$') {
+            if ($len === 1) {
+                return;
+            }
             $expression = substr($expression, 1);
+            $len--;
         }
 
         if ($expression[0] !== '.' && $expression[0] !== '[') {
             $expression = '.' . $expression;
+            $len++;
         }
 
         $this->expression = $expression;
-        $this->expressionLength = strlen($expression);
+        $this->expressionLength = $len;
     }
 
     public function parseExpressionTokens()

--- a/tests/JSONPathLexerTest.php
+++ b/tests/JSONPathLexerTest.php
@@ -133,7 +133,6 @@ class JSONPathLexerTest extends \PHPUnit_Framework_TestCase
 
     }
 
-
     public function test_Recursive_Simple()
     {
         $tokens = (new \Flow\JSONPath\JSONPathLexer('..foo'))->parseExpression();
@@ -142,7 +141,6 @@ class JSONPathLexerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $tokens[0]->value);
         $this->assertEquals('foo', $tokens[1]->value);
     }
-
 
     public function test_Recursive_Wildcard()
     {
@@ -153,7 +151,6 @@ class JSONPathLexerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('*', $tokens[1]->value);
     }
 
-
     /**
      * @expectedException           Flow\JSONPath\JSONPathException
      * @expectedExceptionMessage    Unable to parse token ba^r in expression: ..ba^r
@@ -162,7 +159,6 @@ class JSONPathLexerTest extends \PHPUnit_Framework_TestCase
     {
         $tokens = (new JSONPathLexer('..ba^r'))->parseExpression();
     }
-
 
     /**
      */
@@ -181,7 +177,10 @@ class JSONPathLexerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([1,2,3], $tokens[0]->value);
     }
 
-
+    public function test_Root_Expression()
+    {
+        $tokens = (new JSONPathLexer('$'));
+    }
 
 
 


### PR DESCRIPTION
Fixes #27 
Added a test for this case.

Please merge the request of @oleg-andreyev (#23) and add PHP 7.2 to the travis config.