### PR TITLE
#16 added `Negative Lookahead` to MATCH_INDEX

### DIFF
--- a/src/Flow/JSONPath/JSONPathLexer.php
+++ b/src/Flow/JSONPath/JSONPathLexer.php
@@ -9,7 +9,7 @@ class JSONPathLexer
      * Match within bracket groups
      * Matches are whitespace insensitive
      */
-    const MATCH_INDEX        = '\w+ | \*'; // Eg. foo
+    const MATCH_INDEX        = '(?!\-)[\-\w]+ | \*'; // Eg. foo, 40f35757-2563-4790-b0b1-caa904be455f
     const MATCH_INDEXES      = '\s* -?\d+ [-?\d,\s]+'; // Eg. 0,1,2
     const MATCH_SLICE        = '[-\d:]+ | :'; // Eg. [0:2:1]
     const MATCH_QUERY_RESULT = '\s* \( .+? \) \s*'; // Eg. ?(@.length - 1)

--- a/tests/JSONPathDashedIndexTest.php
+++ b/tests/JSONPathDashedIndexTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Flow\JSONPath\Test;
+
+
+use Flow\JSONPath\JSONPath;
+
+class JSONPathDashedIndexTest extends \PHPUnit_Framework_TestCase
+{
+    public function indexDataProvider()
+    {
+        return [
+            // path, data, expected
+            [
+                '$.data[test-test-test]',
+                [
+                    'data' => [
+                        'test-test-test' => 'foo'
+                    ]
+                ],
+                [
+                    'foo'
+                ]
+            ],
+            [
+                '$.data[40f35757-2563-4790-b0b1-caa904be455f]',
+                [
+                    'data' => [
+                        '40f35757-2563-4790-b0b1-caa904be455f' => 'bar'
+                    ]
+                ],
+                [
+                    'bar'
+                ]
+            ]
+        ];
+    }
+
+    /** @dataProvider indexDataProvider */
+    public function testSlice($path, $data, $expected)
+    {
+        $jsonPath = new JSONPath($data);
+        $result = $jsonPath->find($path)->data();
+        $this->assertEquals($expected, $result);
+    }
+}


### PR DESCRIPTION
added `Negative Lookahead` to MATCH_INDEX regex to assert that string does not match `-` (dash) and avoid conflict with MATCH_SLICE

fixes #16