### PR TITLE
Fix filtering keys with punctuation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
       }
     },
     "require": {
-      "php": ">=5.4.0"
+      "php": ">=5.4.0",
+      "ext-json": "*"
     },
     "require-dev": {
       "peekmo/jsonpath": "dev-master",

--- a/src/Flow/JSONPath/Filters/QueryMatchFilter.php
+++ b/src/Flow/JSONPath/Filters/QueryMatchFilter.php
@@ -6,7 +6,7 @@ use Flow\JSONPath\AccessHelper;
 class QueryMatchFilter extends AbstractFilter
 {
     const MATCH_QUERY_OPERATORS = '
-    @(\.(?<key>\w+)|\[["\']?(?<keySquare>.*?)["\']?\])
+    @(\.(?<key>[^ =]+)|\[["\']?(?<keySquare>.*?)["\']?\])
     (\s*(?<operator>==|=|<>|!==|!=|>|<)\s*(?<comparisonValue>.+))?
     ';
 

--- a/tests/JSONPathTest.php
+++ b/tests/JSONPathTest.php
@@ -289,6 +289,18 @@ class JSONPathTest extends TestCase
         $this->assertEquals(['0-553-21311-3', '0-395-19395-8'], $result->data());
     }
 
+	/**
+	 * .data.tokens[?(@.Employee.FirstName)]
+	 * Verify that it is possible to filter with a key containing punctuation
+	 */
+	public function testRecursiveWithQueryMatchWithDots()
+	{
+		$result = (new JSONPath($this->exampleDataWithDots(rand(0, 1))))->find(".data.tokens[?(@.Employee.FirstName)]");
+		$result = json_decode(json_encode($result), true);
+
+		$this->assertEquals([['Employee.FirstName' => 'Jack']], $result);
+	}
+
     /**
      * $..*
      * All members of JSON structure
@@ -602,6 +614,29 @@ class JSONPathTest extends TestCase
 
         return json_decode($json, $asArray);
     }
+
+    public function exampleDataWithDots($asArray = true)
+	{
+		$json = '
+			{
+				"data": {
+					"tokens": [
+						{
+						  "Employee.FirstName": "Jack"
+						},
+						{
+						  "Employee.LastName": "Daniels"
+						},
+						{
+						  "Employee.Email": "jd@example.com"
+						}
+					]
+				}
+			}
+		';
+
+		return json_decode($json, $asArray);
+	}
 
     public function exampleDataWithSimpleIntegers($asArray = true)
     {


### PR DESCRIPTION
This is a simple fix inspired by #50 that fixes filtering keys containing non-letter characters, e.g. `.data.tokens[?(@.Employee.FirstName)]` or `[?(@.neighbor-id == "192.168.1.1")]` as also described in #50.

It basically causes the regex to match everything except `whitespace` and `=`. Let me know if it's too greedy, but all tests are passing.