### PR TITLE
Fixed: move tests to PSR-4 autoloading in autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,12 @@
     ],
     "autoload": {
       "psr-0": {
-        "Flow\\JSONPath": "src/",
-        "Flow\\JSONPath\\Test": "tests/"
+        "Flow\\JSONPath": "src/"
+      }
+    },
+    "autoload-dev": {
+      "psr-4": {
+        "Flow\\JSONPath\\Test\\": "tests/"
       }
     },
     "require": {


### PR DESCRIPTION
Fixes Composer deprecation notice "Deprecation Notice: Class Flow\JSONPath\Test\<classname> located in ./vendor/flow/jsonpath/tests/JSONPathArrayAccessTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201"

Test namespace can be autoloaded only for dev. PSR-0 assumes absolute file structure and was expecting `tests\Flow\JSONPath\Test\` as the namespace. PSR-4 allows defining more relative anchor points.